### PR TITLE
Mr: DCT Code Merge

### DIFF
--- a/ASS-watermarking/DCT.cpp
+++ b/ASS-watermarking/DCT.cpp
@@ -1,5 +1,17 @@
 #include "DCT.hpp"
-#include <iostream>
+
+// Quantitum Matrix: Q_{50}
+// using Q_{50} as a standard to generate other Matrix
+std::vector<double> DCT::Quant_matrix_50 = std::vector<double> {
+        16, 11, 10, 16, 24, 40, 51, 61,
+        12, 12, 14, 19, 26, 58, 60, 55,
+        14, 13, 16, 24, 40, 57, 69, 56,
+        14, 17, 22, 29, 51, 87, 80, 62,
+        18, 22, 37, 56, 68, 109,103,77,
+        24, 35, 55, 64, 81, 104,113,92,
+        49, 64, 78, 87, 103,121,120,101,
+        72, 92, 95, 98, 112,100,103,99
+};
 
 /*
  * only able to process SQUARE
@@ -12,7 +24,7 @@
  */
 std::vector<double> DCT::DCT(
     std::vector<double> pixel_arr,
-    size_t N
+    const size_t N
 ) {
     assert(pixel_arr.size() == N*N);
     std::vector<double> D;
@@ -51,8 +63,8 @@ std::vector<double> DCT::DCT(
  */
 std::vector<double> DCT::DCT_inverse(
     std::vector<double> D,
-    size_t q_level,
-    size_t N
+    const size_t N,
+    size_t q_level
 ) {
     std::vector<double> C, R;
     std::vector<double> Q { DCT::Quant_matrix_gen(q_level) };
@@ -136,7 +148,7 @@ std::vector<double> DCT::Quant_matrix_gen(size_t target_Q) {
  * using std::pair
  */
 std::pair<std::vector<double>, std::vector<double>> DCT::T_matrix_gen(
-    size_t N
+    const size_t N
 ) {
     /*
      * generate a 2-dim vector: T
@@ -195,81 +207,4 @@ std::vector<double> DCT::Mult_square_matrix(
     }
 
     return ret;
-}
-
-
-/*
- * test part
- */
-void test_DCT() {
-    /*
-     * both test data and algothrim from "Image Compression and the Discrete Cosine Transform",
-     * which written by Ken Cabeen and Peter Gent.
-     */
-    std::vector<double> vec {
-        26, -5, -5, -5, -5, -5, -5, 8,
-        64, 52, 8, 26, 26, 26, 8, -18,
-        126, 70 ,26, 26, 52, 26, -5, -5,
-        111, 52, 8, 52, 52, 38, -5, -5,
-        52, 26, 8, 39, 38, 21, 8, 8,
-        0, 8, -5, 8, 26, 52, 70, 26,
-        -5, -23, -18, 21, 8, 8, 52, 38,
-        -18, 8, -5, -5, -5, 8, 26, 8
-    };
-    vec = DCT::DCT(vec, 8);
-    for (double elem : vec) {
-        std::cout << elem << " ";
-    }
-    std::cout << std::endl;
-
-    vec = DCT::DCT_inverse(vec, 50, 8);
-    for (double elem : vec) {
-        std::cout << elem << " ";
-    }
-}
-
-void test_Q_gen() {
-    std::vector<double> vec { DCT::Quant_matrix_gen(90) };
-    for (double elem : vec)
-        std::cout << elem << " ";
-    std::cout << std::endl;
-
-    vec = DCT::Quant_matrix_gen(10);
-    for (double elem : vec)
-        std::cout << elem << " ";
-    std::cout << std::endl;
-
-    vec = DCT::Quant_matrix_gen(50);
-    for (double elem : vec)
-        std::cout << elem << " ";
-    std::cout << std::endl;
-}
-
-// test well
-void test_T_transpose() {
-    std::pair<std::vector<double>, std::vector<double>> vec { DCT::T_matrix_gen(8) };
-    std::vector<double> T { vec.first };
-    std::vector<double> T_tp { vec.second };
-
-    for (double elem : T)
-        std::cout << elem << " ";
-    std::cout << std::endl;
-    for (double elem : T_tp)
-        std::cout << elem << " ";
-}
-
-// test well
-void test_mult() {
-    std::vector<double> a {4,2,1,4};
-    std::vector<double> b {3,5,8,7};
-    a = DCT::Mult_square_matrix(a,b);
-    for (double elem : a)
-        std::cout << elem << " ";
-}
-
-int main() {
-    test_DCT();
-    //test_Q_gen();
-    //test_T_transpose();
-    //test_mult();
 }

--- a/ASS-watermarking/DCT.cpp
+++ b/ASS-watermarking/DCT.cpp
@@ -1,0 +1,127 @@
+#include "DCT.hpp"
+#include <iostream>
+
+/*
+ * only able to process SQUARE
+ * get D Matrix from M(pixel_arr) directly
+ * without T and T^T generation
+ * (T is an Orthogonal Matrix)
+ *
+ * In M(pixel_arr), i means column, j means row,
+ * so is D Matrix
+ */
+std::vector<double> DCT::DCT(
+    std::vector<double> pixel_arr,
+    size_t N
+) {
+    assert(pixel_arr.size() == N*N);
+    std::vector<double> D;
+
+    /*
+     * i: column
+     * j: row
+     *
+     * D(i,j) = D: row j column i
+     */
+    for (size_t j = 0; j < N; ++j)
+        for (size_t i = 0; i < N; ++i) {
+            double C_i = (i == 0) ? 1.0 / sqrt(2) : 1;
+            double C_j = (j == 0) ? 1.0 / sqrt(2) : 1;
+
+            double D_i_j = 0;
+            for (size_t y = 0; y < N; ++y)
+                for (size_t x = 0; x < N; ++x) {
+                    double theta_1 = ((2*x + 1)*i*M_PI) / (2.0*N);
+                    double theta_2 = ((2*y + 1)*j*M_PI) / (2.0*N);
+                    D_i_j += pixel_arr[y*N + x] * cos(theta_1) * cos(theta_2);
+                }
+            D_i_j *= (1.0 / sqrt(2*N)) * C_i * C_j;
+            D.push_back(D_i_j);
+        }
+
+    return D;
+}
+
+std::vector<double> DCT::DCT_inverse(
+    std::vector<double> pixel_arr,
+    size_t N
+) {
+    assert(pixel_arr.size() == N*N);
+    /* TODO: inverse function of DCT */
+}
+
+size_t DCT::bound(double input) {
+    if (input > 255)
+        return 255;
+    else if (input < 0)
+        return 0;
+    else
+        return ceil(input);
+}
+
+/*
+ * the function comes from the highest reply post in:
+ * https://stackoverflow.com/questions/29215879/how-can-i-generalize-the-quantization-matrix-in-jpeg-compression
+ *
+ * through test(test_Q_gen),
+ * this function can generate Q Matrix(e.g. Q_{10} and Q_{90}) that given by dct.pdf.
+ */
+std::vector<double> DCT::Quant_matrix_gen(size_t target_Q) {
+    size_t S;
+    if (target_Q < 50)
+        S = 5000 / target_Q;
+    else
+        S = 200 - 2*target_Q;
+
+    std::vector<double> ret;
+    for (double elem : DCT::Quant_matrix_50) {
+        size_t input = floor((S*elem + 50) / 100);
+        ret.push_back(DCT::bound(input));
+    }
+    return ret;
+}
+
+void test_DCT() {
+    /*
+     * both test data and algothrim from "Image Compression and the Discrete Cosine Transform",
+     * which written by Ken Cabeen and Peter Gent.
+     */
+    std::vector<double> vec {
+        26, -5, -5, -5, -5, -5, -5, 8,
+        64, 52, 8, 26, 26, 26, 8, -18,
+        126, 70 ,26, 26, 52, 26, -5, -5,
+        111, 52, 8, 52, 52, 38, -5, -5,
+        52, 26, 8, 39, 38, 21, 8, 8,
+        0, 8, -5, 8, 26, 52, 70, 26,
+        -5, -23, -18, 21, 8, 8, 52, 38,
+        -18, 8, -5, -5, -5, 8, 26, 8
+    };
+    vec = DCT::DCT(vec, 8);
+    for (double elem : vec) {
+        std::cout << elem << " ";
+    }
+    std::cout << std::endl;
+
+    vec = DCT::DCT_inverse(vec, 8);
+    for (double elem : vec) {
+        std::cout << elem << " ";
+    }
+
+}
+
+void test_Q_gen() {
+    std::vector<double> vec { DCT::Quant_matrix_gen(90) };
+    for (double elem : vec)
+        std::cout << elem << " ";
+    std::cout << std::endl;
+
+    vec = DCT::Quant_matrix_gen(10);
+    for (double elem : vec)
+        std::cout << elem << " ";
+    std::cout << std::endl;
+}
+
+int main() {
+    //test_DCT();
+    test_Q_gen();
+}

--- a/ASS-watermarking/DCT.hpp
+++ b/ASS-watermarking/DCT.hpp
@@ -40,4 +40,9 @@ namespace DCT {
         std::vector<double>,
         std::vector<double>
     > T_matrix_gen(size_t N);
+
+    std::vector<double> Mult_square_matrix(
+        std::vector<double> a,
+        std::vector<double> b
+    );
 }

--- a/ASS-watermarking/DCT.hpp
+++ b/ASS-watermarking/DCT.hpp
@@ -26,12 +26,18 @@ namespace DCT {
 
     std::vector<double> DCT_inverse(
         std::vector<double> pixel_arr,
+        size_t q_level,
         size_t N
     );
 
-    size_t bound(double input);
+    int round(double input, bool unsign=1);
 
     std::vector<double> Quant_matrix_gen(
         size_t target_Q
     );
+
+    std::pair<
+        std::vector<double>,
+        std::vector<double>
+    > T_matrix_gen(size_t N);
 }

--- a/ASS-watermarking/DCT.hpp
+++ b/ASS-watermarking/DCT.hpp
@@ -8,26 +8,17 @@
 
 namespace DCT {
 
-    std::vector<double> Quant_matrix_50 {
-        16, 11, 10, 16, 24, 40, 51, 61,
-        12, 12, 14, 19, 26, 58, 60, 55,
-        14, 13, 16, 24, 40, 57, 69, 56,
-        14, 17, 22, 29, 51, 87, 80, 62,
-        18, 22, 37, 56, 68, 109,103,77,
-        24, 35, 55, 64, 81, 104,113,92,
-        49, 64, 78, 87, 103,121,120,101,
-        72, 92, 95, 98, 112,100,103,99
-    };
+    extern std::vector<double> Quant_matrix_50;
 
     std::vector<double> DCT(
         std::vector<double> pixel_arr,
-        size_t N
+        const size_t N
     );
 
     std::vector<double> DCT_inverse(
         std::vector<double> pixel_arr,
-        size_t q_level,
-        size_t N
+        const size_t N,
+        size_t q_level=50
     );
 
     int round(double input, bool unsign=1);
@@ -39,7 +30,7 @@ namespace DCT {
     std::pair<
         std::vector<double>,
         std::vector<double>
-    > T_matrix_gen(size_t N);
+    > T_matrix_gen(const size_t N);
 
     std::vector<double> Mult_square_matrix(
         std::vector<double> a,

--- a/ASS-watermarking/DCT.hpp
+++ b/ASS-watermarking/DCT.hpp
@@ -1,0 +1,37 @@
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+
+#include <vector>
+#include <cmath>
+#include <cassert>
+
+namespace DCT {
+
+    std::vector<double> Quant_matrix_50 {
+        16, 11, 10, 16, 24, 40, 51, 61,
+        12, 12, 14, 19, 26, 58, 60, 55,
+        14, 13, 16, 24, 40, 57, 69, 56,
+        14, 17, 22, 29, 51, 87, 80, 62,
+        18, 22, 37, 56, 68, 109,103,77,
+        24, 35, 55, 64, 81, 104,113,92,
+        49, 64, 78, 87, 103,121,120,101,
+        72, 92, 95, 98, 112,100,103,99
+    };
+
+    std::vector<double> DCT(
+        std::vector<double> pixel_arr,
+        size_t N
+    );
+
+    std::vector<double> DCT_inverse(
+        std::vector<double> pixel_arr,
+        size_t N
+    );
+
+    size_t bound(double input);
+
+    std::vector<double> Quant_matrix_gen(
+        size_t target_Q
+    );
+}

--- a/ASS-watermarking/test/test_DCT.cpp
+++ b/ASS-watermarking/test/test_DCT.cpp
@@ -1,0 +1,79 @@
+#include "DCT.hpp"
+#include <iostream>
+using namespace DCT;
+
+/*
+ * test part
+ */
+void test_DCT() {
+    /*
+     * both test data and algothrim from "Image Compression and the Discrete Cosine Transform",
+     * which written by Ken Cabeen and Peter Gent.
+     */
+    std::vector<double> vec {
+        26, -5, -5, -5, -5, -5, -5, 8,
+        64, 52, 8, 26, 26, 26, 8, -18,
+        126, 70 ,26, 26, 52, 26, -5, -5,
+        111, 52, 8, 52, 52, 38, -5, -5,
+        52, 26, 8, 39, 38, 21, 8, 8,
+        0, 8, -5, 8, 26, 52, 70, 26,
+        -5, -23, -18, 21, 8, 8, 52, 38,
+        -18, 8, -5, -5, -5, 8, 26, 8
+    };
+    vec = DCT::DCT(vec, 8);
+    for (double elem : vec) {
+        std::cout << elem << " ";
+    }
+    std::cout << std::endl;
+
+    vec = DCT::DCT_inverse(vec, 50, 8);
+    for (double elem : vec) {
+        std::cout << elem << " ";
+    }
+}
+
+void test_Q_gen() {
+    std::vector<double> vec { DCT::Quant_matrix_gen(90) };
+    for (double elem : vec)
+        std::cout << elem << " ";
+    std::cout << std::endl;
+
+    vec = DCT::Quant_matrix_gen(10);
+    for (double elem : vec)
+        std::cout << elem << " ";
+    std::cout << std::endl;
+
+    vec = DCT::Quant_matrix_gen(50);
+    for (double elem : vec)
+        std::cout << elem << " ";
+    std::cout << std::endl;
+}
+
+// test well
+void test_T_transpose() {
+    std::pair<std::vector<double>, std::vector<double>> vec { DCT::T_matrix_gen(8) };
+    std::vector<double> T { vec.first };
+    std::vector<double> T_tp { vec.second };
+
+    for (double elem : T)
+        std::cout << elem << " ";
+    std::cout << std::endl;
+    for (double elem : T_tp)
+        std::cout << elem << " ";
+}
+
+// test well
+void test_mult() {
+    std::vector<double> a {4,2,1,4};
+    std::vector<double> b {3,5,8,7};
+    a = DCT::Mult_square_matrix(a,b);
+    for (double elem : a)
+        std::cout << elem << " ";
+}
+
+int main() {
+    test_DCT();
+    //test_Q_gen();
+    //test_T_transpose();
+    //test_mult();
+}


### PR DESCRIPTION
# 合入 DCT 相关函数

本次合入内容如下：

* namespace DCT
* DCT test

## 一、DCT namespace

创建了 `DCT` 空间，其中有函数如下：

* DCT
* DCT_inverse
* Mult_square_matrix
* Quant_matrix_gen
* round
* T_matrix_gen

除前二者是其他文件中需要使用的函数之外，下面的四个函数均为前两个函数的工具函数，为简化主体而抽离于二函数。

## 二、test

编写相关 `test` 函数，基于 `slide` 中的数据对 `DCT`, `DCT_inverse`, `Mult_square_matrix`, `round` 进行了测试。